### PR TITLE
Eslint update

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -23,7 +23,7 @@ export default tseslint.config(
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.app.json'],
+        project: ['./tsconfig.app.json', './tsconfig.node.json'],
         tsconfigRootDir: import.meta.dirname,
       },
       ecmaVersion: 2020,

--- a/frontend/src/authentication/logout.ts
+++ b/frontend/src/authentication/logout.ts
@@ -1,4 +1,3 @@
-// logout.ts
 export interface LogoutResponse {
   message: string;
 }

--- a/frontend/src/components/context/AuthContext.tsx
+++ b/frontend/src/components/context/AuthContext.tsx
@@ -1,7 +1,7 @@
 // components/context/AuthContext.tsx
 import { createContext } from "react";
 
-interface AuthContextType {
+export interface AuthContextType {
   isLoggedIn: boolean | null;
   loading: boolean;
   refresh: () => Promise<void>;

--- a/frontend/src/components/context/useAuth.ts
+++ b/frontend/src/components/context/useAuth.ts
@@ -1,6 +1,6 @@
 import { use } from "react";
-import { AuthContext } from "./AuthContext";
+import { AuthContext, AuthContextType } from "./AuthContext";
 
-export const useAuth = () => {
+export const useAuth = (): AuthContextType => {
   return use(AuthContext);
 };

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
@@ -12,7 +13,8 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
     "jsx": "react-jsx",
 
     /* Linting */

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "files": [],
+  "include": ["src", "vite.config.ts"],
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "lib": ["ES2023"],
@@ -11,7 +12,8 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
fix lint issue for vite.config.ts not found in parserOptions.project, fix by modifying tsconfig.json to include both src and vite.config.ts and let eslint.config.js use it, instead of using the original tsconfig.app.json.